### PR TITLE
Automatically run 'meteor add' on packages that are cloned

### DIFF
--- a/packages.js
+++ b/packages.js
@@ -85,6 +85,26 @@ var checkPathExist = function (path, errorMessage) {
   }
 };
 
+var getPackageName = function (dest) {
+  var packageJsPath = dest + '/package.js',
+    packageName = false,
+    lines = [];
+  checkPathExist(packageJsPath, 'package.js file not found.');
+
+  fs.ensureFileSync(packageJsPath);
+  packageJsContents = fs.readFileSync(packageJsPath, 'utf8');
+
+  lines = packageJsContents.split(/\n/g);
+  for (line in lines) {
+    if (/name/.test(lines[line]) && (lines[line].match(/:/g).length >= 2)) {
+      packageName = lines[line].split(/:(.+)?/)[1].trim().replace(/\"/g, '').replace(/\'/g, '').replace(/,/g, '');
+      break;
+    }
+  }
+
+  return packageName;
+}
+
 /**
  * Create a git ignore in the package directory for the packages.
  * @param packages
@@ -203,6 +223,9 @@ Packages.load = function (packages, callback) {
           shell.cp('-rf', src + '.', dest);
           checkPathExist(dest, 'Cannot copy package: ' + dest);
           shell.echo('Done...\n');
+
+          packageName = getPackageName(dest);
+          shell.echo('Meteor package name: ' + packageName);
         });
       });
     });


### PR DESCRIPTION
This pull request implements a code change that will automatically get the package name from each of the cloned packages. When it is finished cloning, it will then loop through each of the packages it was able to find the name for and run `meteor add` to add them to the project's `.meteor/packages` and `.meteor/versions` files so that the developer does not need to do that manually after running `mgp`.